### PR TITLE
SSR1PCB fixes

### DIFF
--- a/ESP32/lib/pinMap.h
+++ b/ESP32/lib/pinMap.h
@@ -559,6 +559,9 @@ class PinMapSSR1PCB : public PinMapSSR1 {
             setPwmChannel3(17);
             setHallEffect(14);
 
+            setI2cSda(22);
+            setI2cScl(21);
+
             setValve(-1);
             setTwist(-1);
             setSqueeze(-1);

--- a/ESP32/src/TCode/v0.3/BLDCHandler0_3.h
+++ b/ESP32/src/TCode/v0.3/BLDCHandler0_3.h
@@ -283,6 +283,10 @@ public:
         // These functions query the t-code object for the position/level at a specified time
         // Number recieved will be an integer, 0-9999
         int xLin = channelRead("L0");
+        if (m_settingsFactory->getInverseStroke())
+        {
+            xLin = 9999 - xLin;
+        }
         //LogHandler::verbose(_TAG, "xLin: %ld", xLin);
 
 

--- a/ESP32/src/TCode/v0.4/BLDCHandler0_4.h
+++ b/ESP32/src/TCode/v0.4/BLDCHandler0_4.h
@@ -286,6 +286,10 @@ public:
         // These functions query the t-code object for the position/level at a specified time
         // Number recieved will be an integer, 0-9999
         int xLin = channelRead(stroke_axis);
+        if (m_settingsFactory->getInverseStroke())
+        {
+            xLin = 9999 - xLin;
+        }
         //LogHandler::verbose(_TAG, "xLin: %ld", xLin);
 
 


### PR DESCRIPTION
Swap SDA and SCL defaults for SSR1PCB.

Enable inversion in software.