### PR TITLE
Fix swapped L1/L2 channels in TCode v0.3 SR6

### DIFF
--- a/ESP32/src/TCode/v0.3/ServoHandler0_3.h
+++ b/ESP32/src/TCode/v0.3/ServoHandler0_3.h
@@ -311,8 +311,8 @@ private:
 
     void executeSR6(int strokeTcode, int rollTcode, int pitchTcode) 
     {
-        yLin = channelRead(TCODE_CHANNEL_SWAY);
-        zLin = channelRead(TCODE_CHANNEL_SURGE);
+        yLin = channelRead(TCODE_CHANNEL_SURGE);
+        zLin = channelRead(TCODE_CHANNEL_SWAY);
         // SR6 Kinematics
         // Calculate arm angles
         int roll,pitch,fwd,thrust,side;


### PR DESCRIPTION
## Changes
- Swap the two `channelRead` calls in `executeSR6` to match v0.4:
  - `yLin` ← `TCODE_CHANNEL_SURGE` (L1, Forward)
  - `zLin` ← `TCODE_CHANNEL_SWAY` (L2, Left)